### PR TITLE
chore(packages): reserve `syner` and `@syner` scope in NPM

### DIFF
--- a/packages/sdk/LICENSE
+++ b/packages/sdk/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 SynerOps, Inc
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,8 +1,15 @@
 {
   "name": "@syner/sdk",
-  "version": "0.0.0",
+  "version": "0.0.0-dev.1",
+  "description": "Syner Agentic Framework SDK - Build autonomous systems",
   "type": "module",
-  "private": true,
+  "private": false,
+  "license": "MIT",
+  "author": {
+    "name": "SynerOps, Inc",
+    "email": "info@synerops.com",
+    "url": "https://synerops.com"
+  },
   "exports": {
     "./package.json": "./package.json",
     ".": {

--- a/packages/sdk/src/agents/orchestrator.ts
+++ b/packages/sdk/src/agents/orchestrator.ts
@@ -18,38 +18,76 @@ export type OrchestratorSettings = AgentSettings<
   OrchestratorTools,
   OrchestratorOutput
 > & {
-  team?: Record<string, Agent<ToolSet, unknown>>
+  team?: Map<string, Agent<ToolSet, unknown>> | Record<string, Agent<ToolSet, unknown>>
 }
 
 export interface OrchestratorContract {
   generate(
     options: Prompt & { 
-      team?: Record<string, Agent<ToolSet, unknown>>
+      team?: Map<string, Agent<ToolSet, unknown>> | Record<string, Agent<ToolSet, unknown>>
     }
   ): Promise<GenerateTextResult<OrchestratorTools, OrchestratorOutput>>
 
   getTeam(): string[]
+  addAgent(name: string, agent: Agent<ToolSet, unknown>): void
+  removeAgent(name: string): boolean
+  hasAgent(name: string): boolean
+  getAgent(name: string): Agent<ToolSet, unknown> | undefined
 }
 
 export class Orchestrator extends Agent<
   OrchestratorTools,
   OrchestratorOutput
 > implements OrchestratorContract {
-  protected team: Record<string, Agent<ToolSet, unknown>> = {}
+  private _team = new Map<string, Agent<ToolSet, unknown>>()
 
-  constructor(_options: OrchestratorSettings) {
-    super({} as OrchestratorSettings)
+  constructor(options: OrchestratorSettings) {
+    super(options as AgentSettings<OrchestratorTools, OrchestratorOutput>)
+    if (options.team) {
+      this.team = options.team
+    }
+  }
+  
+  set team(value: Map<string, Agent<ToolSet, unknown>> | Record<string, Agent<ToolSet, unknown>>) {
+    if (value instanceof Map) {
+      this._team = value
+    } else {
+      this._team = new Map(Object.entries(value))
+    }
+  }
+
+  get team(): Map<string, Agent<ToolSet, unknown>> {
+    return this._team
   }
   
   generate(
-    _options: Prompt & { 
-      team?: Record<string, Agent<ToolSet, unknown>>
+    options: Prompt & { 
+      team?: Map<string, Agent<ToolSet, unknown>> | Record<string, Agent<ToolSet, unknown>>
     }
   ): Promise<GenerateTextResult<OrchestratorTools, OrchestratorOutput>> {
-    return this.generate(_options)
+    if (options.team) {
+      this.team = options.team
+    }
+    return super.generate(options)
   }
 
   getTeam(): string[] {
-    return Object.keys(this.team)
+    return Array.from(this._team.keys())
+  }
+
+  addAgent(name: string, agent: Agent<ToolSet, unknown>): void {
+    this._team.set(name, agent)
+  }
+
+  removeAgent(name: string): boolean {
+    return this._team.delete(name)
+  }
+
+  hasAgent(name: string): boolean {
+    return this._team.has(name)
+  }
+
+  getAgent(name: string): Agent<ToolSet, unknown> | undefined {
+    return this._team.get(name)
   }
 }

--- a/packages/syner/package.json
+++ b/packages/syner/package.json
@@ -1,9 +1,24 @@
 {
   "name": "syner",
   "description": "syner OS: the agentic operating system implemented with syner SDK",
-  "version": "0.0.0",
+  "version": "0.0.0-dev.1",
   "type": "module",
-  "private": true,
+  "private": false,
+  "license": "AGPL-3.0-only",
+  "author": {
+    "name": "Ronny Badilla",
+    "email": "info@rbadillap.dev",
+    "url": "https://rbadillap.dev"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/synerops/syner.git",
+    "directory": "packages/syner"
+  },
+  "homepage": "https://github.com/synerops/syner#readme",
+  "bugs": {
+    "url": "https://github.com/synerops/syner/issues"
+  },
   "exports": {
     "./package.json": "./package.json",
     ".": {

--- a/packages/syner/src/agents/orchestrator.ts
+++ b/packages/syner/src/agents/orchestrator.ts
@@ -1,13 +1,20 @@
-import { Experimental_Agent as Agent } from "ai";
+// import { Experimental_Agent as Agent } from "ai";
 
-import type {
-  OrchestratorTools,
-  OrchestratorOutput,
-  OrchestratorSettings,
-} from "@syner/sdk/agents";
+// import type {
+//   OrchestratorTools,
+//   OrchestratorOutput,
+//   OrchestratorSettings,
+// } from "@syner/sdk/agents";
+import { Orchestrator } from "@syner/sdk/agents";
 
-export class Orchestrator extends Agent<OrchestratorTools, OrchestratorOutput> {
-  constructor(options: OrchestratorSettings) {
-    super(options);
-  }
-}
+// class Orchestrator extends Agent<OrchestratorTools, OrchestratorOutput> {
+//   constructor(options: OrchestratorSettings) {
+//     super(options);
+//   }
+// }
+
+export const orchestrator = new Orchestrator({
+  model: "xai/grok-4-fast-reasoning",
+  system:
+    "You are Syner, an AI agent designed to orchestrate tasks and manage resources within a team.",
+});

--- a/packages/syner/tsconfig.json
+++ b/packages/syner/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@syner/ts-config/base",
+  "compilerOptions": {
+    // Build handled by tsup - this config is only for type checking and IDE
+    "incremental": false,
+    "types": [],
+    "baseUrl": "."
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "tsup.config.ts"]
+}
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,6 +70,9 @@ importers:
 
   apps/workspace:
     dependencies:
+      '@syner/sdk':
+        specifier: workspace:*
+        version: link:../../packages/sdk
       ai:
         specifier: ^5.0.68
         version: 5.0.68(zod@4.1.12)


### PR DESCRIPTION
Officially we own `syner` and `@syner` scopes 🥹

- [@syner/sdk](https://www.npmjs.com/package/@syner/sdk)
- [syner](https://www.npmjs.com/package/syner)