### PR TITLE
docs: complete documentation audit with /docs skill

### DIFF
--- a/.claude/skills/docs/SKILL.md
+++ b/.claude/skills/docs/SKILL.md
@@ -1,0 +1,283 @@
+---
+name: docs
+description: Review and maintain documentation across the Syner OS monorepo
+user_invocable: true
+---
+
+# Documentation Review Skill
+
+You are a documentation reviewer for Syner OS. Your job is to analyze, review, and help maintain documentation across the monorepo following established standards.
+
+## When to Use
+
+- User runs `/docs` to review documentation
+- User asks to check if docs are up to date
+- User wants to create or update README.md or AGENTS.md files
+
+## Documentation Philosophy
+
+Syner OS uses a two-file documentation system:
+
+| File | Audience | Purpose |
+|------|----------|---------|
+| `README.md` | Humans | Why this exists, how to set it up |
+| `AGENTS.md` | AI Agents | How to work here, what to use, rules |
+
+These files serve different purposes and should NOT duplicate content.
+
+## Structure by Level
+
+### Apps (`apps/*/`)
+
+Apps are entry points to the system. Humans need to understand the app's purpose. Agents need to know routes and how to test.
+
+**README.md Structure:**
+```markdown
+# {App Name}
+
+## What is {App Name}?
+
+{Human-friendly, non-technical explanation of why this app exists and what value it provides. 2-3 paragraphs max.}
+
+## Getting Started
+
+### Prerequisites
+{What you need before starting}
+
+### Installation
+{Step by step setup}
+
+### Development
+{How to run locally, ports, commands}
+
+## Learn More
+
+{Links to related docs, OS Protocol, etc.}
+```
+
+**AGENTS.md Structure:**
+```markdown
+# {App Name}
+
+{One-line: what this app does in the Syner OS system}
+
+## Routes
+
+| Path | Method | Description |
+|------|--------|-------------|
+| `/api/v1/...` | POST | ... |
+
+## Structure
+
+{Brief explanation of folder organization if non-obvious}
+
+## Testing
+
+```bash
+curl -s -X POST http://localhost:{port}/api/... \
+  -H "Content-Type: application/json" \
+  -d '{}' | jq .
+```
+
+## Environment
+
+{Required env vars for this app, if any}
+```
+
+---
+
+### Packages (`packages/*/`)
+
+Packages are building blocks. Humans need to understand what it exports and how to use it. Agents need architecture, exports, and rules.
+
+**README.md Structure:**
+```markdown
+# {Package Name}
+
+## What is {Package Name}?
+
+{Human-friendly explanation of what this package does and why it exists. Connect it to the larger Syner OS vision.}
+
+## Installation
+
+```bash
+bun add {package-name}
+```
+
+## Usage
+
+{Basic usage examples}
+
+## API
+
+{Public API reference - can link to more detailed docs}
+
+## Related
+
+- [OS Protocol](https://github.com/synerops/protocol) - {if applicable}
+- {Other relevant links}
+```
+
+**AGENTS.md Structure:**
+```markdown
+# {Package Name}
+
+{One-line: what this package implements or provides}
+
+## Architecture
+
+{Diagram or explanation of internal structure}
+
+## Exports
+
+```typescript
+// Main entry
+import { ... } from '{package-name}'
+
+// Subpath exports
+import { ... } from '{package-name}/subpath'
+```
+
+## Key Concepts
+
+{Important abstractions or patterns to understand}
+
+## Rules
+
+**MUST:**
+- {Required behaviors}
+
+**NEVER:**
+- {Prohibited behaviors}
+
+**SHOULD:**
+- {Recommended behaviors}
+```
+
+---
+
+### Extensions (`extensions/*/`)
+
+Extensions are vendor integrations that provide tools for Syner OS agents. Humans need to understand what vendor capability is available. Agents need quick usage and key files.
+
+**README.md Structure:**
+```markdown
+# @syner/{vendor}
+
+{Vendor} integration for Syner OS.
+
+## What is this?
+
+{Human-friendly explanation: This extension brings {Vendor}'s {capability} into Syner OS as tools that agents can use. Explain the VALUE - what can agents do with this?}
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `{toolName}()` | {What it does} |
+
+## Setup
+
+### 1. {Vendor} Account
+{How to get credentials from the vendor}
+
+### 2. Environment Variables
+```env
+{VENDOR}_API_KEY=...
+```
+
+### 3. Installation
+```bash
+bun add @syner/{vendor}
+```
+
+## API Reference
+
+{Detailed API documentation}
+
+## License
+
+MIT
+```
+
+**AGENTS.md Structure:**
+```markdown
+# @syner/{vendor}
+
+{One-line: what interface from OS Protocol this implements}
+
+## Usage
+
+```typescript
+import { ... } from '@syner/{vendor}/...'
+
+// Minimal working example
+```
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `src/...` | {What it does} |
+
+## Environment
+
+Requires `{ENV_VAR}` for {purpose}.
+```
+
+---
+
+### Tooling (`tooling/*/`)
+
+Tooling packages are internal configs. No AGENTS.md needed. README should be minimal but clear.
+
+**README.md Structure:**
+```markdown
+# @syner/{config}
+
+Shared {config type} configuration for Syner OS projects.
+
+## Why?
+
+{Brief explanation of why this config is centralized}
+
+## Usage
+
+```js
+// How to use this config in a project
+```
+
+## What's Included
+
+{List of rules, plugins, or settings - keep it brief}
+```
+
+---
+
+## Review Process
+
+When reviewing documentation, check:
+
+1. **Existence**: Does the file exist where it should?
+2. **Audience**: Is README human-friendly? Is AGENTS.md agent-friendly?
+3. **Structure**: Does it follow the level-appropriate template?
+4. **Accuracy**: Does it reflect the current state of the code?
+5. **No Duplication**: Is content duplicated between README and AGENTS.md?
+6. **Links**: Are there helpful links to OS Protocol or related packages?
+
+## Commands
+
+When user runs `/docs`:
+
+1. Ask what they want to review (specific package, level, or full audit)
+2. Read the relevant files
+3. Compare against the templates above
+4. Report findings: what's missing, what's outdated, what's good
+5. Offer to fix issues if requested
+
+## Example Invocations
+
+- `/docs` - Start interactive review
+- `/docs apps/os` - Review specific app
+- `/docs packages` - Review all packages
+- `/docs audit` - Full monorepo audit

--- a/.claude/skills/docs/SKILL.md
+++ b/.claude/skills/docs/SKILL.md
@@ -272,8 +272,34 @@ When user runs `/docs`:
 1. Ask what they want to review (specific package, level, or full audit)
 2. Read the relevant files
 3. Compare against the templates above
-4. Report findings: what's missing, what's outdated, what's good
+4. Report findings with three categories:
+   - **Needs Work**: Missing files, incomplete content
+   - **No Changes Needed**: Files that are complete and follow templates
+   - **Actions Recommended**: Prioritized list of fixes
 5. Offer to fix issues if requested
+
+## Report Format
+
+Always include all three sections in your audit report:
+
+```markdown
+## Needs Work
+| Location | Issue |
+|----------|-------|
+| `apps/dev` | Missing AGENTS.md |
+
+## No Changes Needed
+| Location | Status |
+|----------|--------|
+| `extensions/github` | README.md and AGENTS.md complete |
+
+## Recommended Actions
+**Priority High:** ...
+**Priority Medium:** ...
+**Priority Low:** ...
+```
+
+This ensures the user sees both what needs fixing AND what's already good.
 
 ## Example Invocations
 

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,8 @@ npm-debug.log*
 !README.md
 !AGENTS.md
 !SYNER.md
+!SKILL.md
 !**/README.md
 !**/AGENTS.md
+!**/SKILL.md
 .env*.local

--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,8 @@ npm-debug.log*
 # apps/workspace
 
 # Claude Code
-.claude/
+.claude/*
+!.claude/skills/
 
 # Planning files (local only)
 *.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,10 +3,10 @@
 ## What is Syner OS?
 
 Syner OS is a **Semantic and Agentic Operating System** where:
-1. Users can create and orchestrate AI agents
-2. **Syner** (default agent) is a meta-orchestrator that chooses workflow patterns
-3. The "source code" of Syner are `.md` files (SKILL.md, AGENT.md, etc.)
-4. Users modify these files to customize behavior
+
+1. **Semantic**: The "source code" are `.md` files (SKILL.md, AGENT.md) that define behavior in natural language
+2. **Agentic**: AI agents orchestrate workflows, with **Syner** as the default meta-orchestrator
+3. Users create, customize, and orchestrate agents by modifying markdown files
 
 ## Three-Layer Architecture
 
@@ -18,7 +18,6 @@ Syner OS is a **Semantic and Agentic Operating System** where:
 │  - TypeScript interfaces in @osprotocol/schema              │
 │  - "A Filesystem MUST have readFile(), writeFile()"         │
 │  - Agnostic to implementation                               │
-│  - The "law" that everyone must follow                      │
 └─────────────────────────────────────────────────────────────┘
                            │
                            │ implements
@@ -28,7 +27,6 @@ Syner OS is a **Semantic and Agentic Operating System** where:
 │            (DEFAULT Implementation)                         │
 │                                                             │
 │  - @syner/sdk provides base workflow classes                │
-│  - lib/: Runtime (parser, loader, discovery)                │
 │  - Works out-of-the-box without extensions                  │
 └─────────────────────────────────────────────────────────────┘
                            │
@@ -38,11 +36,9 @@ Syner OS is a **Semantic and Agentic Operating System** where:
 │                    EXTENSIONS                               │
 │           (ALTERNATIVE Implementations)                     │
 │                                                             │
-│  @syner/vercel:                                             │
-│    - VercelFilesystem (uses Vercel API)                     │
-│    - VercelSandbox (secure execution)                       │
-│                                                             │
-│  Other vendors can create their own extensions              │
+│  @syner/github   - GitHub OAuth and API                     │
+│  @syner/upstash  - Distributed Redis cache                  │
+│  @syner/vercel   - Secure sandbox execution                 │
 └─────────────────────────────────────────────────────────────┘
 ```
 
@@ -52,128 +48,38 @@ Syner OS is a **Semantic and Agentic Operating System** where:
 
 Syner uses hierarchical AGENTS.md files to avoid redundancy:
 
-- `/AGENTS.md` (this file) - Project overview, what is Syner OS
-- `/apps/*/AGENTS.md` - App-specific architecture and rules
-- `/packages/*/AGENTS.md` - Package-specific architecture and rules
+| Location | Purpose |
+|----------|---------|
+| `/AGENTS.md` | Project vision and architecture (this file) |
+| `/CLAUDE.md` | Commands, structure, coding conventions |
+| `/apps/*/AGENTS.md` | App-specific rules |
+| `/packages/*/AGENTS.md` | Package architecture |
+| `/extensions/*/AGENTS.md` | Extension usage and APIs |
 
 **Rules:**
-
-- Root AGENTS.md = context ("what is this?")
-- Package AGENTS.md = architecture ("how does it work?")
+- Root = context ("what is this?")
+- CLAUDE.md = technical reference ("how do I work here?")
+- Package/Extension = implementation details ("how does X work?")
 - NEVER duplicate information across levels
-- Read root first, then navigate to package for details
 
-## OS Protocol Specification
+## OS Protocol
 
-**IMPORTANT**: Before implementing agents, modifying the SDK, or working with the agent loop (context/actions/checks), you MUST fetch and understand the OS Protocol specification.
-
-**When to fetch the protocol**:
-
-- Before building new agents
-- Before modifying SDK core functionality
-- When implementing context/actions/checks APIs
-- When working on the agent loop or orchestration
-- When you need to understand the contract that all agents must follow
-
-**How to fetch**:
-Run this command to get the latest protocol specification (only fetch when needed to save tokens):
+Before implementing agents or modifying the SDK, fetch the protocol specification:
 
 ```bash
-curl -s --location 'https://raw.githubusercontent.com/synerops/protocol/refs/heads/main/AGENTS.md' \
---header 'Accept: text/markdown'
+curl -s 'https://raw.githubusercontent.com/synerops/protocol/refs/heads/main/AGENTS.md'
 ```
 
 The protocol defines:
-
-- The agent loop contract (context → actions → checks → repeat)
-- MUST/NEVER rules that all implementations must follow
+- Agent loop contract: `context (read) → actions (execute) → checks (validate) → repeat`
+- MUST/NEVER rules for all implementations
 - Interface contracts for Agent, Context, Action, and Check primitives
-- Communication patterns between agents
 
-### Signed TODOs
+## Domains
 
-All TODOs MUST be signed with the author's identifier for traceability:
-
-```typescript
-// ✅ Correct
-// TODO(@claude): Awaiting Ronny's approval - description of what's pending
-
-// ✅ Correct
-// TODO(@syner): Refactor this when we migrate to v2
-
-// ❌ Wrong - unsigned TODO
-// TODO: Fix this later
-```
-
-## Project Structure
-
-This monorepo contains:
-
-```
-apps/
-├── os/                      # syner.app + syner.bot (API at /api/v1/*)
-└── docs/                    # syner.dev (documentation)
-
-packages/
-├── sdk/                     # @syner/sdk - OS Protocol implementation
-│   └── src/
-│       ├── lib/             # Runtime infrastructure (NOT part of protocol)
-│       │   ├── parser.ts    # Parses .md files (SKILL.md, AGENT.md)
-│       │   ├── loader.ts    # Loads tools dynamically
-│       │   ├── discovery.ts # Discovers skills/agents
-│       │   └── types.ts     # SDK-specific types
-│       ├── system/          # protocol/system/* (env, fs, preferences, registry)
-│       ├── context/         # protocol/context/* (memory, documents)
-│       ├── actions/         # protocol/actions/* (tools, ops)
-│       ├── checks/          # protocol/checks/* (rules, audit)
-│       ├── skills/          # protocol/skills/* (orchestrator, planner, executor)
-│       ├── workflows/       # protocol/workflows/* implementations
-│       └── runs/            # protocol/runs/* control
-│
-├── syner/                   # Default orchestrator agent
-│   ├── AGENT.md             # Syner as agent definition
-│   ├── PERSONALITY.md       # Default personality
-│   ├── RULES.md             # Default rules
-│   └── src/                 # AI SDK-specific implementations
-│
-└── ui/                      # @syner/ui - Shared components
-
-extensions/
-└── vercel/                  # @syner/vercel - Vercel sandbox integration
-    └── src/system/sandbox/  # Extends SDK system/
-
-tooling/                     # eslint, prettier, typescript configs
-```
-
-**Domains:**
-- `syner.app` → apps/os (UI + API)
-- `syner.bot` → apps/os/api/v1/* (same deploy, different domain)
-- `syner.dev` → apps/docs
-
-## Skills Architecture
-
-Skills use the SKILL.md format (inspired by Anthropic Skills) for discovery and loading:
-
-```yaml
----
-name: fs
-description: File system operations
-protocol:
-  domain: system
-  api: fs
----
-
-# Filesystem
-
-## Capabilities
-- Read files and directories
-- Write and create files
-
-## When to Use
-- User needs to read or write files
-```
-
-Each skill directory contains:
-- `SKILL.md` - Skill metadata and documentation
-- `tools/` - AI SDK tool implementations
-- `index.ts` - Module exports
+| Domain | App | Purpose |
+|--------|-----|---------|
+| `syner.app` | apps/os | Main OS interface |
+| `syner.bot` | apps/os/api/v1/* | API (same deploy) |
+| `syner.dev` | apps/dev | Developer hub, docs, auth |
+| `syner.design` | apps/design | Design system documentation |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,8 +49,9 @@ The SDK re-exports protocol types for convenience, but extensions should always 
 
 ```
 apps/
-├── os/          # Main Syner OS Next.js application
-└── dev/         # Developer hub (syner.dev) - Auth, APIs, Devkit, Docs
+├── os/          # Main Syner OS Next.js application (port 3000)
+├── dev/         # Developer hub (syner.dev) - Auth, APIs, Devkit, Docs (port 3002)
+└── design/      # Design system documentation (port 3003)
 
 packages/
 ├── sdk/         # @syner/sdk - TypeScript OS Protocol implementation
@@ -124,6 +125,24 @@ Version catalogs are defined in root `package.json` under `workspaces.catalogs`:
 
 Usage: `"dependency": "catalog:catalogName"`
 
+## Environment Variables
+
+For `apps/dev` and extensions, copy `.env.example` to `.env.local`:
+
+```bash
+# GitHub OAuth (@syner/github)
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
+
+# GitHub App - server-to-server
+GITHUB_APP_ID=
+GITHUB_PRIVATE_KEY=
+
+# Upstash Redis (@syner/upstash)
+UPSTASH_REDIS_REST_URL=
+UPSTASH_REDIS_REST_TOKEN=
+```
+
 ## External Dependencies
 
 Before implementing agents or modifying SDK core:
@@ -160,11 +179,3 @@ curl -s -X POST http://localhost:3000/api/workflows/routing \
   -d '{"prompt": "Write a function to sort an array"}' | jq .
 ```
 
-## Documentation Hierarchy
-
-Syner uses hierarchical AGENTS.md files:
-- `/AGENTS.md` - Project overview (what is Syner OS)
-- `/apps/*/AGENTS.md` - App-specific rules
-- `/packages/*/AGENTS.md` - Package-specific architecture
-
-Read root first, then navigate to package for implementation details.

--- a/apps/design/AGENTS.md
+++ b/apps/design/AGENTS.md
@@ -1,0 +1,50 @@
+# Design System
+
+Component documentation app showcasing `@syner/ui` with interactive previews.
+
+## Routes
+
+| Path | Method | Description |
+|------|--------|-------------|
+| `/` | GET | Home page |
+| `/components/[slug]` | GET | Component documentation page |
+
+## Structure
+
+```
+app/
+├── components/[[...slug]]/  # Dynamic component docs
+├── layout.tsx               # Root layout with providers
+└── page.tsx                 # Home page
+
+content/
+└── components/              # MDX documentation
+    ├── button.mdx
+    ├── tooltip.mdx
+    ├── toaster.mdx
+    └── meta.json            # Navigation order
+
+components/
+├── component-preview.tsx    # Preview container
+└── code-block.tsx           # Code display
+```
+
+## Adding Components
+
+1. Create MDX in `content/components/{name}.mdx`
+2. Use `<ComponentPreview>` for interactive examples
+3. Add to `meta.json` pages array
+
+## Testing
+
+```bash
+# Run dev server
+cd apps/design && bun run dev
+
+# Access at http://localhost:3003
+```
+
+## Dependencies
+
+- `@syner/ui` - Component library (workspace)
+- `fumadocs-*` - Documentation framework

--- a/apps/dev/AGENTS.md
+++ b/apps/dev/AGENTS.md
@@ -1,0 +1,45 @@
+# Developer Hub
+
+Documentation site and API gateway for Syner OS (syner.dev).
+
+## Routes
+
+| Path | Method | Description |
+|------|--------|-------------|
+| `/api/auth/github` | GET | Initiate GitHub OAuth flow |
+| `/api/auth/github/callback` | GET | OAuth callback handler |
+| `/api/github/content` | GET | Fetch file content from GitHub repos |
+| `/api/search` | GET | Documentation search (Fumadocs/Orama) |
+| `/llms-full.txt` | GET | Full documentation export for LLMs |
+
+## Structure
+
+```
+app/
+├── api/
+│   ├── auth/github/       # OAuth flow
+│   ├── github/content/    # Content API
+│   └── search/            # Docs search
+├── docs/[[...slug]]/      # Documentation pages
+└── llms-full.txt/         # LLM export route
+```
+
+## Testing
+
+```bash
+# Initiate OAuth (redirects to GitHub)
+curl -s http://localhost:3002/api/auth/github?origin=dev
+
+# Fetch GitHub content (requires auth)
+curl -s "http://localhost:3002/api/github/content?owner=synerops&repo=syner&path=README.md"
+
+# Search docs
+curl -s "http://localhost:3002/api/search?q=sdk" | jq .
+```
+
+## Environment
+
+| Variable | Purpose |
+|----------|---------|
+| `GITHUB_CLIENT_ID` | GitHub OAuth app client ID |
+| `GITHUB_CLIENT_SECRET` | GitHub OAuth app secret |

--- a/apps/dev/README.md
+++ b/apps/dev/README.md
@@ -1,3 +1,53 @@
-# Docs
+# Syner Developer Hub
 
-Documentation site for Syner OS (syner.dev) built with Next.js and Fumadocs.
+## What is the Developer Hub?
+
+The Developer Hub (syner.dev) is the central documentation and API gateway for Syner OS. It serves developers who want to build with the OS Protocol, providing documentation, GitHub integration, and developer tools.
+
+The hub connects your GitHub repositories to Syner OS, enabling agents to access your codebase through authenticated APIs with intelligent caching.
+
+## Getting Started
+
+### Prerequisites
+
+- [Bun](https://bun.sh/) v1.0+
+- GitHub OAuth App credentials
+
+### Installation
+
+```bash
+# From monorepo root
+bun install
+
+# Copy environment template
+cp apps/dev/.env.example apps/dev/.env.local
+```
+
+### Environment Variables
+
+```env
+# GitHub OAuth (required for GitHub features)
+GITHUB_CLIENT_ID=your-client-id
+GITHUB_CLIENT_SECRET=your-client-secret
+```
+
+### Development
+
+```bash
+# Run the dev hub
+bunx turbo run dev --filter=dev
+```
+
+The app runs at `http://localhost:3002`.
+
+## Features
+
+- **Documentation** - Full OS Protocol and SDK documentation
+- **GitHub OAuth** - Connect GitHub accounts for repo access
+- **Content API** - Fetch repository files with ETag caching
+- **LLM Export** - Full documentation export for AI assistants
+
+## Learn More
+
+- [OS Protocol](https://github.com/synerops/protocol) - The specification
+- [GitHub App Setup](https://docs.github.com/en/apps/creating-github-apps) - Create OAuth credentials

--- a/apps/os/AGENTS.md
+++ b/apps/os/AGENTS.md
@@ -1,13 +1,55 @@
 # Syner OS Application
 
-## Testing Endpoints
+Main runtime for the Agentic Operating System implementing the OS Protocol.
 
-**IMPORTANT**: When testing API endpoints, always use `curl -s` (silent mode) and pipe to `jq` for formatted JSON output.
+## Routes
 
-### Example
+| Path | Method | Description |
+|------|--------|-------------|
+| `/api/v1/chat` | POST | Main chat endpoint with agent loop |
+| `/api/workflows/routing` | POST | Test routing workflow classification |
+
+## Structure
+
+```
+app/
+├── api/v1/
+│   └── chat/route.ts      # Main agent endpoint
+├── (os)/api/
+│   └── workflows/         # Workflow test endpoints
+│       └── routing/       # Routing classification test
+└── lib/
+    ├── identity.ts        # Load agent identity (AGENT.md, PERSONALITY.md, RULES.md)
+    ├── skills.ts          # Skill discovery and tool loading
+    └── agent-loop.ts      # Loop state and step handlers
+```
+
+## Testing
 
 ```bash
-curl -s -X POST http://localhost:3000/api/chat \
+# Chat API v1
+curl -s -X POST http://localhost:3000/api/v1/chat \
   -H "Content-Type: application/json" \
-  -d '{}' | jq .
+  -d '{"prompt": "Hello, who are you?"}' | jq .
+
+# Routing workflow test
+curl -s -X POST http://localhost:3000/api/workflows/routing \
+  -H "Content-Type: application/json" \
+  -d '{"prompt": "I need a refund"}' | jq .
 ```
+
+## Environment
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `SYNER_ORCHESTRATOR_MODEL` | `anthropic/claude-haiku-4.5` | Model for routing/orchestration |
+
+## Agent Loop
+
+The chat endpoint implements the OS Protocol agent loop:
+
+1. **Load Identity** - AGENT.md, PERSONALITY.md, RULES.md from `syner` package
+2. **Initialize Skills** - Discover SKILL.md files and load tools
+3. **Build System Prompt** - Combine identity with skill descriptions
+4. **Execute Loop** - context → actions → checks → repeat
+5. **Return Response** - Text, steps summary, sandbox state

--- a/apps/os/README.md
+++ b/apps/os/README.md
@@ -1,1 +1,43 @@
 # Syner OS
+
+## What is Syner OS?
+
+Syner OS is an Agentic Operating System that implements the [OS Protocol](https://github.com/synerops/protocol) specification. It provides a runtime environment where AI agents can operate with identity, skills, and structured workflows.
+
+The OS enables agents to follow a disciplined loop: gather context, execute actions, validate with checks, and repeat. This pattern ensures predictable, auditable agent behavior.
+
+## Getting Started
+
+### Prerequisites
+
+- [Bun](https://bun.sh/) v1.0+
+- Node.js 20+
+
+### Installation
+
+```bash
+# Clone the repository
+git clone https://github.com/synerops/syner.git
+cd syner
+
+# Install dependencies
+bun install
+```
+
+### Development
+
+```bash
+# Run the OS application
+bun run dev
+
+# Or run only the OS app
+bunx turbo run dev --filter=os
+```
+
+The app runs at `http://localhost:3000`.
+
+## Learn More
+
+- [OS Protocol](https://github.com/synerops/protocol) - The specification
+- [@syner/sdk](../packages/sdk) - TypeScript SDK
+- [syner.dev](https://syner.dev) - Documentation

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,3 +1,67 @@
-# SDK
+# @syner/sdk
 
-TypeScript implementation of the Syner OS Protocol with primitives for building agents.
+## What is @syner/sdk?
+
+The SDK is the TypeScript implementation of the [OS Protocol](https://github.com/synerops/protocol) specification. It provides the building blocks for creating AI agents that operate within a structured, predictable framework.
+
+The SDK sits in the middle layer of the architecture: Protocol defines the contracts, SDK provides default implementations, and Extensions replace specific capabilities with vendor integrations.
+
+## Installation
+
+```bash
+bun add @syner/sdk
+```
+
+## Usage
+
+```typescript
+import { Routing, env, createMemoryCache } from '@syner/sdk'
+import { discoverSkills } from '@syner/sdk/lib'
+
+// Discover available skills
+const skills = await discoverSkills('./skills')
+
+// Create a routing workflow
+const router = new Routing({
+  model: gateway('anthropic/claude-haiku'),
+  workflows: {
+    support: { workflow: supportWf, description: 'Technical support' },
+    billing: { workflow: billingWf, description: 'Billing inquiries' },
+  }
+})
+
+// Run the workflow
+const result = await router.run('I need help with my account')
+```
+
+## API
+
+### Workflows
+
+| Class | Purpose |
+|-------|---------|
+| `Routing` | Classify input and delegate to specialized workflows |
+| `OrchestratorWorkers` | Plan, delegate to workers, synthesize results |
+| `Parallelization` | Split into subtasks, run in parallel, merge |
+| `EvaluatorOptimizer` | Generate, evaluate, iteratively improve |
+
+### Data
+
+| Function | Purpose |
+|----------|---------|
+| `createMemoryCache()` | In-memory cache with LRU eviction |
+| `env.getSandbox()` | Get current sandbox from environment |
+
+### Skills
+
+| Function | Purpose |
+|----------|---------|
+| `discoverSkills(path)` | Find SKILL.md files recursively |
+| `parseSkillFile(content)` | Parse YAML frontmatter from skill |
+| `loadSkillTools(skill)` | Dynamically load skill's tools |
+
+## Related
+
+- [OS Protocol](https://github.com/synerops/protocol) - The specification
+- [@syner/upstash](../../extensions/upstash) - Distributed cache implementation
+- [@syner/vercel](../../extensions/vercel) - Sandbox implementation

--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -1,0 +1,48 @@
+# @syner/ui
+
+Shared UI components and design system for Syner OS applications.
+
+## Exports
+
+```typescript
+// Styles (import in app layout)
+import '@syner/ui/globals.css'
+
+// Components
+import { Button } from '@syner/ui/components/button'
+import { Tooltip, TooltipProvider, TooltipTrigger, TooltipContent } from '@syner/ui/components/tooltip'
+import { Toaster, toast } from '@syner/ui/components/sonner'
+
+// Branding
+import { Logo, Wordmark, Logomark } from '@syner/ui/branding/logo'
+
+// Utilities
+import { cn } from '@syner/ui/lib/utils'
+```
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `src/styles/globals.css` | Base styles, CSS variables, Tailwind |
+| `src/components/button.tsx` | Button with variants (default, destructive, outline, ghost, link) |
+| `src/components/tooltip.tsx` | Radix tooltip wrapper |
+| `src/components/sonner.tsx` | Toast notifications |
+| `src/branding/logo.tsx` | Logo components |
+| `src/lib/utils.ts` | `cn()` classname utility |
+
+## Rules
+
+**MUST:**
+- Import styles via `@syner/ui/globals.css` in app layout
+- Use `TooltipProvider` at app root for tooltips
+- Use subpath imports (`@syner/ui/components/button`)
+
+**NEVER:**
+- Import from package root (`@syner/ui`)
+- Define component styles outside this package
+- Use raw Radix components directly (use wrappers)
+
+**SHOULD:**
+- Use `cn()` for conditional classnames
+- Follow existing variant patterns when adding components

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,3 +1,76 @@
-# UI
+# @syner/ui
 
-Shared UI components and design system for Syner OS applications.
+## What is @syner/ui?
+
+The UI package provides shared components and design system for all Syner OS applications. It ensures visual consistency across the ecosystem with a unified set of primitives built on Radix UI and Tailwind CSS.
+
+Components are designed to be accessible, themeable, and composable. The package exports everything needed to build Syner applications: components, styles, utilities, and branding assets.
+
+## Installation
+
+```bash
+bun add @syner/ui
+```
+
+## Usage
+
+### 1. Import Global Styles
+
+In your app's root layout:
+
+```tsx
+import '@syner/ui/globals.css'
+```
+
+### 2. Use Components
+
+```tsx
+import { Button } from '@syner/ui/components/button'
+import { Tooltip, TooltipProvider, TooltipTrigger, TooltipContent } from '@syner/ui/components/tooltip'
+import { Toaster, toast } from '@syner/ui/components/sonner'
+
+// Wrap app with TooltipProvider
+function App() {
+  return (
+    <TooltipProvider>
+      <Button onClick={() => toast.success('Hello!')}>
+        Click me
+      </Button>
+      <Toaster />
+    </TooltipProvider>
+  )
+}
+```
+
+### 3. Branding
+
+```tsx
+import { Logo, Wordmark, Logomark } from '@syner/ui/branding/logo'
+
+<Logo />      // Full logo with wordmark
+<Wordmark />  // Text only
+<Logomark />  // Icon only
+```
+
+## API
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `Button` | Primary action button with variants |
+| `Tooltip` | Accessible tooltip with Radix |
+| `Toaster` | Toast notifications with Sonner |
+
+### Utilities
+
+| Export | Purpose |
+|--------|---------|
+| `cn()` | Merge Tailwind classes with clsx + tailwind-merge |
+| `globals.css` | Base styles, CSS variables, animations |
+
+## Related
+
+- [Design System](../../apps/design) - Interactive component documentation
+- [Radix UI](https://radix-ui.com) - Accessible primitives
+- [Tailwind CSS](https://tailwindcss.com) - Utility-first CSS

--- a/tooling/eslint/README.md
+++ b/tooling/eslint/README.md
@@ -1,3 +1,37 @@
-# `@syner/eslint-config`
+# @syner/eslint
 
-Shared eslint configuration for the workspace.
+Shared ESLint configuration for Syner OS projects.
+
+## Why?
+
+Centralizing ESLint config ensures consistent code style and catches common issues across all packages. Each config is composable, so you pick only what you need.
+
+## Usage
+
+```js
+// eslint.config.js
+import base from "@syner/eslint/base";
+import react from "@syner/eslint/react";
+import next from "@syner/eslint/next";
+
+export default [...base, ...react, ...next];
+```
+
+## Available Configs
+
+| Config | Export | Purpose |
+|--------|--------|---------|
+| Base | `@syner/eslint/base` | TypeScript, imports, turbo |
+| React | `@syner/eslint/react` | React hooks, JSX rules |
+| Next.js | `@syner/eslint/next` | Next.js specific rules |
+| A11y | `@syner/eslint/a11y` | Accessibility (jsx-a11y) |
+
+## What's Included
+
+- `typescript-eslint` - TypeScript-aware linting
+- `eslint-plugin-import` - Import/export validation
+- `eslint-plugin-react` - React best practices
+- `eslint-plugin-react-hooks` - Hooks rules
+- `eslint-plugin-jsx-a11y` - Accessibility checks
+- `@next/eslint-plugin-next` - Next.js rules
+- `eslint-plugin-turbo` - Turborepo cache rules

--- a/tooling/typescript/README.md
+++ b/tooling/typescript/README.md
@@ -1,3 +1,40 @@
-# `@syner/typescript-config`
+# @syner/typescript
 
-Shared typescript configuration for the workspace.
+Shared TypeScript configuration for Syner OS projects.
+
+## Why?
+
+Centralizing TypeScript config ensures consistent compiler options and type checking across all packages. Configs are composable and extend from a strict base.
+
+## Usage
+
+```json
+{
+  "extends": "@syner/typescript/nextjs",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}
+```
+
+## Available Configs
+
+| Config | Export | Purpose |
+|--------|--------|---------|
+| Base | `@syner/typescript/base` | Strict base config |
+| React | `@syner/typescript/react` | React JSX settings |
+| Next.js | `@syner/typescript/nextjs` | Next.js optimized |
+
+## What's Included
+
+**Base config:**
+- `strict: true` - All strict checks enabled
+- `noUncheckedIndexedAccess: true` - Safer array/object access
+- `moduleResolution: "bundler"` - Modern resolution
+- `verbatimModuleSyntax: true` - Explicit type imports
+
+**Next.js config extends base with:**
+- `jsx: "preserve"` - Let Next.js handle JSX
+- `plugins` for Next.js compiler


### PR DESCRIPTION
## Summary

- Add missing AGENTS.md files for `apps/dev`, `apps/design`, and `packages/ui`
- Expand incomplete README.md and AGENTS.md across apps, packages, and tooling
- Improve `/docs` skill to include "No Changes Needed" section in reports

## Changes

**New files (3):**
- `apps/dev/AGENTS.md`
- `apps/design/AGENTS.md`
- `packages/ui/AGENTS.md`

**Expanded files (7):**
- `apps/os/README.md` and `AGENTS.md`
- `apps/dev/README.md`
- `packages/sdk/README.md`
- `packages/ui/README.md`
- `tooling/eslint/README.md`
- `tooling/typescript/README.md`

**Skill improvement:**
- `.claude/skills/docs/SKILL.md` now includes explicit report format with three categories

## Test plan

- [ ] Run `/docs audit` to verify new report format shows "No Changes Needed" section
- [ ] Verify all new AGENTS.md files follow the template structure
- [ ] Check that expanded READMEs have proper sections (What is, Getting Started, Usage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)