### PR TITLE
feat: add /task skill with intent detection

### DIFF
--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: task
+description: >
+  Entry point for any task. Detects user intent, classifies complexity,
+  and decides the next step (respond, execute, plan, or delegate).
+  Use as first step before invoking specific workflows.
+---
+
+# /task — Intent Detection & Routing
+
+Universal entry point for Syner. Analyzes input, detects intent,
+and decides the optimal path.
+
+## Pattern
+
+```
+input → classify(intent, complexity) → route(action)
+```
+
+## Process
+
+1. **Read** the user input
+2. **Classify intent** using the schema in assets/intent.md
+3. **Evaluate complexity** (depth, width)
+4. **Decide action**:
+   - `direct` → respond inline
+   - `execute` → use worker
+   - `plan` → EnterPlanMode
+   - `delegate` → invoke appropriate workflow
+   - `clarify` → AskUserQuestion
+
+## Reference
+
+See [references/intent.md](references/intent.md) for classification
+patterns and decision criteria.
+
+## Mapping Intent → Workflow
+
+| Intent Type | Workflow |
+|-------------|----------|
+| direct | none (inline response) |
+| execute | /route → worker |
+| plan | EnterPlanMode |
+| delegate (simple) | /route |
+| delegate (complex) | /orchestrate |
+| delegate (parallel) | /parallelize |
+| delegate (quality) | /evaluate |
+
+## Rules
+
+- ALWAYS produce structured output (assets/intent.md schema)
+- NEVER assume complexity without analysis
+- If confidence < 0.7, request clarification
+- Respect OS Protocol: context → actions → checks

--- a/apps/design/package.json
+++ b/apps/design/package.json
@@ -6,6 +6,7 @@
     "build": "next build",
     "dev": "next dev --port 3003",
     "start": "next start",
+    "clean": "rm -rf .next .turbo",
     "postinstall": "fumadocs-mdx"
   },
   "dependencies": {

--- a/apps/dev/app/[[...slug]]/(home)/components/hero.tsx
+++ b/apps/dev/app/[[...slug]]/(home)/components/hero.tsx
@@ -23,8 +23,10 @@ export const Hero = () => (
       </span>
     </h1>
     <p className="max-w-xl text-balance text-center text-muted-foreground md:max-w-2xl md:text-lg">
-      Define agents using SKILL.md and AGENT.md files. No programming required.
-      Syner OS implements the OS Protocol for building multi-agentic systems.
+      Define agents using SYNER.md files. No programming required.
+      Syner OS implements the{" "}
+      <a href="https://osprotocol.dev" target="_blank" rel="noreferrer" className="underline underline-offset-4 hover:text-foreground">OS Protocol</a>{" "}
+      for building multi-agentic systems.
     </p>
     <div className="mx-auto flex w-full max-w-lg flex-col items-center gap-4 sm:flex-row sm:justify-center">
       <Button asChild size="lg">

--- a/apps/dev/content/docs/intent.mdx
+++ b/apps/dev/content/docs/intent.mdx
@@ -1,0 +1,80 @@
+---
+title: Intent
+description: How Syner classifies user requests
+---
+
+# Intent
+
+> The Intent object represents Syner's classification of a user request,
+> determining the optimal path for execution.
+
+## Initial State
+
+When a user sends a request, Syner produces an IntentClassification
+before taking any action.
+
+## Intent Types
+
+| Type | Description | Next Action |
+|------|-------------|-------------|
+| `direct` | Simple question, no tools needed | Respond inline |
+| `execute` | Clear task, single agent | Route to worker |
+| `plan` | Complex, needs exploration | Enter plan mode |
+| `delegate` | Requires specialist | Route to appropriate agent |
+| `clarify` | Ambiguous request | Ask for clarification |
+
+## Complexity Assessment
+
+```json
+{
+  "depth": 3,
+  "width": 2,
+  "estimated": "moderate"
+}
+```
+
+### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `depth` | `number` | Sequential steps estimated (1-5) |
+| `width` | `number` | Specialties required (1-5) |
+| `estimated` | `string` | `simple`, `moderate`, or `complex` |
+
+## Routing
+
+Based on intent and complexity, Syner chooses:
+
+| Condition | Action |
+|-----------|--------|
+| `direct` | Respond inline |
+| `execute` | `/route` → worker |
+| `plan` | `EnterPlanMode` |
+| `delegate` + simple | `/route` |
+| `delegate` + complex | `/orchestrate` |
+
+## Full Schema
+
+See [`intent.ts`](https://github.com/synerops/syner/blob/main/packages/syner/intent.ts)
+
+## Related
+
+- [/task skill](/docs/task) — Skill that produces IntentClassification
+- [Workflows](/workflows) — Patterns triggered by routing
+
+## Sources
+
+### Anthropic
+
+- [Building Effective Agents](https://www.anthropic.com/research/building-effective-agents) — Official patterns for routing, orchestration, and evaluation
+- [Claude Code Documentation](https://docs.anthropic.com/en/docs/claude-code) — EnterPlanMode and complexity criteria
+
+### Frameworks
+
+- [LangGraph: Routing](https://langchain-ai.github.io/langgraph/concepts/agentic_concepts/#routing) — Classification and delegation patterns
+- [OpenAI Cookbook: Orchestrating Agents](https://cookbook.openai.com/examples/orchestrating_agents) — Multi-agent routing examples
+
+### Research
+
+- [ReAct: Synergizing Reasoning and Acting](https://arxiv.org/abs/2210.03629) — Foundation of the agent loop (reason → act → observe)
+- [Chain-of-Thought Prompting](https://arxiv.org/abs/2201.11903) — Theoretical basis for evaluating reasoning depth

--- a/apps/dev/package.json
+++ b/apps/dev/package.json
@@ -6,6 +6,7 @@
     "build": "next build",
     "dev": "next dev --port 3002",
     "start": "next start",
+    "clean": "rm -rf .next .turbo",
     "postinstall": "fumadocs-mdx"
   },
   "dependencies": {

--- a/apps/os/app/layout.tsx
+++ b/apps/os/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/apps/os/app/page.tsx
+++ b/apps/os/app/page.tsx
@@ -1,0 +1,7 @@
+export default function Home() {
+  return (
+    <main>
+      <h1>Syner OS</h1>
+    </main>
+  )
+}

--- a/apps/os/package.json
+++ b/apps/os/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "bun --bun next dev",
     "build": "bun --bun next build",
-    "start": "next start"
+    "start": "next start",
+    "clean": "rm -rf .next .turbo"
   },
   "dependencies": {
     "next": "catalog:next16",

--- a/bun.lock
+++ b/bun.lock
@@ -607,7 +607,7 @@
 
     "@orama/orama": ["@orama/orama@3.1.18", "", {}, "sha512-a61ljmRVVyG5MC/698C8/FfFDw5a8LOIvyOLW5fztgUXqUpc1jOfQzOitSCbge657OgXXThmY3Tk8fpiDb4UcA=="],
 
-    "@osprotocol/schema": ["@osprotocol/schema@0.2.2", "", {}, "sha512-YnCoep7iBE1g2ZeLFl2c7ujwSYSLpemrPLEjPsw/RDTJoEA28pGEGT6UCSwf0wiLY+OoMfFI6EtdpZ90EUD8jg=="],
+    "@osprotocol/schema": ["@osprotocol/schema@0.2.3", "", {}, "sha512-ZseQHwZxpNEGDae4rxAf5VQtYudFCXQi3iS80zhB//tzgnm6y09YJNhxpalYPxF+8ytPQbtZ8mJngA5pgFE1sQ=="],
 
     "@radix-ui/number": ["@radix-ui/number@1.1.1", "", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
 
@@ -2100,6 +2100,8 @@
     "@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
     "@radix-ui/react-tooltip/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@syner/upstash/@osprotocol/schema": ["@osprotocol/schema@0.2.2", "", {}, "sha512-YnCoep7iBE1g2ZeLFl2c7ujwSYSLpemrPLEjPsw/RDTJoEA28pGEGT6UCSwf0wiLY+OoMfFI6EtdpZ90EUD8jg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
 

--- a/extensions/github/package.json
+++ b/extensions/github/package.json
@@ -51,7 +51,7 @@
     "lint": "eslint . --max-warnings 0",
     "format": "prettier --check . --ignore-path ../../.gitignore",
     "format:fix": "prettier --write . --ignore-path ../../.gitignore",
-    "clean": "git clean -xdf .cache .next .turbo dist node_modules"
+    "clean": "rm -rf dist .turbo"
   },
   "dependencies": {
     "@octokit/plugin-throttling": "^9",

--- a/extensions/upstash/package.json
+++ b/extensions/upstash/package.json
@@ -44,7 +44,7 @@
     "lint": "eslint . --max-warnings 0",
     "format": "prettier --check . --ignore-path ../../.gitignore",
     "format:fix": "prettier --write . --ignore-path ../../.gitignore",
-    "clean": "git clean -xdf .cache .turbo dist node_modules"
+    "clean": "rm -rf dist .turbo"
   },
   "dependencies": {
     "@osprotocol/schema": "catalog:osprotocol",

--- a/extensions/vercel/package.json
+++ b/extensions/vercel/package.json
@@ -45,7 +45,7 @@
     "lint": "eslint . --max-warnings 0",
     "format": "prettier --check . --ignore-path ../../.gitignore",
     "format:fix": "prettier --write . --ignore-path ../../.gitignore",
-    "clean": "git clean -xdf .cache .next .turbo dist node_modules"
+    "clean": "rm -rf dist .turbo"
   },
   "dependencies": {
     "@vercel/sandbox": "latest",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "build": "turbo --no-update-notifier run build",
     "dev": "turbo run dev --parallel",
     "lint": "turbo lint",
-    "clean": "turbo clean",
+    "clean": "turbo clean && rm -rf .turbo",
     "typecheck": "turbo typecheck",
     "format": "turbo format"
   },

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -53,7 +53,7 @@
     "lint": "eslint . --max-warnings 0",
     "format": "prettier --check . --ignore-path ../../.gitignore",
     "format:fix": "prettier --write . --ignore-path ../../.gitignore",
-    "clean": "git clean -xdf .cache .next .turbo dist node_modules"
+    "clean": "rm -rf dist .turbo"
   },
   "dependencies": {
     "@osprotocol/schema": "catalog:osprotocol"

--- a/packages/syner/SYNER.md
+++ b/packages/syner/SYNER.md
@@ -3,6 +3,8 @@ name: syner
 description: Main orchestrator agent. Use when coordinating work across specialists, planning multi-step tasks, or when the task involves Syner's identity.
 tools: Task(orchestrator, worker, specialist, reviewer, auditor)
 model: opus
+skills:
+  - task
 ---
 
 # syner

--- a/packages/syner/intent.ts
+++ b/packages/syner/intent.ts
@@ -1,0 +1,37 @@
+// syner/packages/syner/intent.ts
+
+export type IntentType = 'direct' | 'execute' | 'plan' | 'delegate' | 'clarify'
+export type ComplexityLevel = 'simple' | 'moderate' | 'complex'
+export type WorkflowType = 'route' | 'orchestrate' | 'parallelize' | 'evaluate'
+export type AgentType = 'worker' | 'specialist' | 'reviewer' | 'orchestrator'
+export type ActionType = 'respond' | 'execute' | 'plan' | 'delegate' | 'ask'
+
+export interface Intent {
+  type: IntentType
+  confidence: number // 0.0 - 1.0
+  rationale: string
+}
+
+export interface Complexity {
+  depth: number // 1-5: sequential steps
+  width: number // 1-5: required specialties
+  estimated: ComplexityLevel
+}
+
+export interface Routing {
+  requires_planning: boolean
+  suggested_workflow: WorkflowType | null
+  suggested_agent: AgentType | null
+}
+
+export interface NextAction {
+  action: ActionType
+  details: string
+}
+
+export interface IntentClassification {
+  intent: Intent
+  complexity: Complexity
+  routing: Routing
+  next_action: NextAction
+}

--- a/packages/syner/package.json
+++ b/packages/syner/package.json
@@ -32,7 +32,7 @@
     "lint": "eslint . --max-warnings 0",
     "format": "prettier --check . --ignore-path ../../.gitignore",
     "format:fix": "prettier --write . --ignore-path ../../.gitignore",
-    "clean": "git clean -xdf .cache .next .turbo dist node_modules"
+    "clean": "rm -rf dist .turbo"
   },
   "dependencies": {
     "@syner/sdk": "workspace:*"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint . --max-warnings 0",
     "format": "prettier --check . --ignore-path ../../.gitignore",
     "format:fix": "prettier --write . --ignore-path ../../.gitignore",
-    "clean": "git clean -xdf .cache .next .turbo node_modules"
+    "clean": "rm -rf .turbo"
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.3",

--- a/turbo.json
+++ b/turbo.json
@@ -2,6 +2,9 @@
   "$schema": "https://turborepo.com/schema.json",
   "ui": "tui",
   "tasks": {
+    "clean": {
+      "cache": false
+    },
     "build": {
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],


### PR DESCRIPTION
## Summary

- Add `/task` skill as Syner's universal entry point for intent classification
- Classify user requests into 5 intent types: `direct`, `execute`, `plan`, `delegate`, `clarify`
- Evaluate complexity (depth/width) before routing to workflows
- Document Intent entity on syner.dev with academic and industry sources
- Standardize `clean` scripts across the monorepo (replace `git clean` with `rm -rf`)

## Changes

| Area | Description |
|------|-------------|
| `.claude/skills/task/` | Skill definition with references and assets |
| `packages/syner/intent.ts` | TypeScript interfaces for IntentClassification |
| `apps/dev/content/docs/intent.mdx` | Public documentation with sources |
| `turbo.json` + `package.json` files | Standardized clean scripts |
| `apps/os/app/` | Minimal placeholder for monorepo dev |

## Test plan

- [ ] Run `bun run clean && bun run dev`
- [ ] Verify http://localhost:3002/docs/intent loads correctly
- [ ] Verify hero links to https://osprotocol.dev