### PR TITLE
feat: add turbo-ignore for Vercel builds

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "bunVersion": "1.x"
+  "bunVersion": "1.x",
+  "ignoreCommand": "npx turbo-ignore"
 }


### PR DESCRIPTION
## Summary

- Configures `turbo-ignore` to skip unnecessary Vercel builds
- Analyzes Turborepo dependency graph to determine if changes affect the app being deployed
- Saves build minutes on PRs that only touch unrelated packages or markdown files

## How it works

| Change | apps/os | apps/dev | apps/design |
|--------|---------|----------|-------------|
| `README.md` | Skip | Skip | Skip |
| `packages/sdk/**` | Build | Build | Skip |
| `packages/ui/**` | Skip | Build | Build |
| `apps/os/**` | Build | Skip | Skip |

## Test plan

- [ ] Verify builds still trigger correctly for relevant changes
- [ ] Create a test PR that only modifies `.md` files and confirm builds are skipped
- [ ] Verify Vercel logs show turbo-ignore output

🤖 Generated with [Claude Code](https://claude.com/claude-code)