### PR TITLE
feat: add @syner/slack extension with client + handler pattern

### DIFF
--- a/apps/dev/app/api/slack/webhook/route.ts
+++ b/apps/dev/app/api/slack/webhook/route.ts
@@ -1,0 +1,64 @@
+/**
+ * Slack Webhook Route
+ *
+ * POST /api/slack/webhook
+ *
+ * Receives all Slack events (mentions, assistant threads, DMs).
+ * The handler from @syner/slack does verification and dispatch —
+ * this route just wires it up.
+ */
+
+import { createHandler, createSlackClient, replyInThread, setAssistantStatus } from '@syner/slack'
+
+function getSlackClient() {
+  const botToken = process.env.SLACK_BOT_TOKEN
+  if (!botToken) throw new Error('Missing SLACK_BOT_TOKEN')
+  return createSlackClient({ botToken })
+}
+
+export const POST = createHandler({
+  signingSecret: process.env.SLACK_SIGNING_SECRET!,
+
+  onAppMention: async (event) => {
+    const client = getSlackClient()
+    await replyInThread(client, {
+      channel: event.channel,
+      threadTs: event.thread_ts ?? event.ts,
+      text: `👋 Got your mention! (syner v0)`,
+    })
+  },
+
+  onAssistantThreadStarted: async (event) => {
+    const client = getSlackClient()
+    const { channel_id, thread_ts } = event.assistant_thread
+    await setAssistantStatus(client, {
+      channelId: channel_id,
+      threadTs: thread_ts,
+      status: 'Thinking...',
+    })
+    await replyInThread(client, {
+      channel: channel_id,
+      threadTs: thread_ts,
+      text: 'Hello! I\'m Syner. How can I help?',
+    })
+  },
+
+  onAssistantThreadContextChanged: async (event) => {
+    const client = getSlackClient()
+    const { channel_id, thread_ts, context } = event.assistant_thread
+    await replyInThread(client, {
+      channel: channel_id,
+      threadTs: thread_ts,
+      text: `Context switched to <#${context.channel_id}>`,
+    })
+  },
+
+  onMessage: async (event) => {
+    const client = getSlackClient()
+    await replyInThread(client, {
+      channel: event.channel,
+      threadTs: event.thread_ts ?? event.ts,
+      text: `Echo: ${event.text}`,
+    })
+  },
+})

--- a/apps/dev/app/api/slack/webhook/route.ts
+++ b/apps/dev/app/api/slack/webhook/route.ts
@@ -6,8 +6,12 @@
  * Receives all Slack events (mentions, assistant threads, DMs).
  * The handler from @syner/slack does verification and dispatch —
  * this route just wires it up.
+ *
+ * Callbacks use `after()` to keep the serverless function alive
+ * after the 200 response is sent to Slack.
  */
 
+import { after } from 'next/server'
 import { createHandler, createSlackClient, replyInThread, setAssistantStatus } from '@syner/slack'
 
 function getSlackClient() {
@@ -20,45 +24,53 @@ export const POST = createHandler({
   signingSecret: process.env.SLACK_SIGNING_SECRET!,
 
   onAppMention: async (event) => {
-    const client = getSlackClient()
-    await replyInThread(client, {
-      channel: event.channel,
-      threadTs: event.thread_ts ?? event.ts,
-      text: `👋 Got your mention! (syner v0)`,
+    after(async () => {
+      const client = getSlackClient()
+      await replyInThread(client, {
+        channel: event.channel,
+        threadTs: event.thread_ts ?? event.ts,
+        text: `👋 Got your mention! (syner v0)`,
+      })
     })
   },
 
   onAssistantThreadStarted: async (event) => {
-    const client = getSlackClient()
-    const { channel_id, thread_ts } = event.assistant_thread
-    await setAssistantStatus(client, {
-      channelId: channel_id,
-      threadTs: thread_ts,
-      status: 'Thinking...',
-    })
-    await replyInThread(client, {
-      channel: channel_id,
-      threadTs: thread_ts,
-      text: 'Hello! I\'m Syner. How can I help?',
+    after(async () => {
+      const client = getSlackClient()
+      const { channel_id, thread_ts } = event.assistant_thread
+      await setAssistantStatus(client, {
+        channelId: channel_id,
+        threadTs: thread_ts,
+        status: 'Thinking...',
+      })
+      await replyInThread(client, {
+        channel: channel_id,
+        threadTs: thread_ts,
+        text: "Hello! I'm Syner. How can I help?",
+      })
     })
   },
 
   onAssistantThreadContextChanged: async (event) => {
-    const client = getSlackClient()
-    const { channel_id, thread_ts, context } = event.assistant_thread
-    await replyInThread(client, {
-      channel: channel_id,
-      threadTs: thread_ts,
-      text: `Context switched to <#${context.channel_id}>`,
+    after(async () => {
+      const client = getSlackClient()
+      const { channel_id, thread_ts, context } = event.assistant_thread
+      await replyInThread(client, {
+        channel: channel_id,
+        threadTs: thread_ts,
+        text: `Context switched to <#${context.channel_id}>`,
+      })
     })
   },
 
   onMessage: async (event) => {
-    const client = getSlackClient()
-    await replyInThread(client, {
-      channel: event.channel,
-      threadTs: event.thread_ts ?? event.ts,
-      text: `Echo: ${event.text}`,
+    after(async () => {
+      const client = getSlackClient()
+      await replyInThread(client, {
+        channel: event.channel,
+        threadTs: event.thread_ts ?? event.ts,
+        text: `Echo: ${event.text}`,
+      })
     })
   },
 })

--- a/apps/dev/package.json
+++ b/apps/dev/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@syner/github": "workspace:*",
     "@syner/sdk": "workspace:*",
+    "@syner/slack": "workspace:*",
     "@syner/ui": "workspace:*",
     "@vercel/analytics": "catalog:vercel",
     "clsx": "^2.1.1",

--- a/bun.lock
+++ b/bun.lock
@@ -47,6 +47,7 @@
       "dependencies": {
         "@syner/github": "workspace:*",
         "@syner/sdk": "workspace:*",
+        "@syner/slack": "workspace:*",
         "@syner/ui": "workspace:*",
         "@vercel/analytics": "catalog:vercel",
         "clsx": "^2.1.1",
@@ -108,6 +109,21 @@
       },
       "peerDependencies": {
         "zod": "catalog:aisdk",
+      },
+    },
+    "extensions/slack": {
+      "name": "@syner/slack",
+      "version": "0.0.0-dev.1",
+      "dependencies": {
+        "@slack/web-api": "^7",
+      },
+      "devDependencies": {
+        "@syner/eslint": "workspace:*",
+        "@syner/prettier": "workspace:*",
+        "@syner/typescript": "workspace:*",
+        "@types/bun": "*",
+        "tsup": "^8.5.0",
+        "typescript": "catalog:",
       },
     },
     "extensions/upstash": {
@@ -745,6 +761,12 @@
 
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
 
+    "@slack/logger": ["@slack/logger@4.0.0", "", { "dependencies": { "@types/node": ">=18.0.0" } }, "sha512-Wz7QYfPAlG/DR+DfABddUZeNgoeY7d1J39OCR2jR+v7VBsB8ezulDK5szTnDDPDwLH5IWhLvXIHlCFZV7MSKgA=="],
+
+    "@slack/types": ["@slack/types@2.20.0", "", {}, "sha512-PVF6P6nxzDMrzPC8fSCsnwaI+kF8YfEpxf3MqXmdyjyWTYsZQURpkK7WWUWvP5QpH55pB7zyYL9Qem/xSgc5VA=="],
+
+    "@slack/web-api": ["@slack/web-api@7.14.1", "", { "dependencies": { "@slack/logger": "^4.0.0", "@slack/types": "^2.20.0", "@types/node": ">=18.0.0", "@types/retry": "0.12.0", "axios": "^1.13.5", "eventemitter3": "^5.0.1", "form-data": "^4.0.4", "is-electron": "2.2.2", "is-stream": "^2", "p-queue": "^6", "p-retry": "^4", "retry": "^0.13.1" } }, "sha512-RoygyteJeFswxDPJjUMESn9dldWVMD2xUcHHd9DenVavSfVC6FeVnSdDerOO7m8LLvw4Q132nQM4hX8JiF7dng=="],
+
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
@@ -756,6 +778,8 @@
     "@syner/prettier": ["@syner/prettier@workspace:tooling/prettier"],
 
     "@syner/sdk": ["@syner/sdk@workspace:packages/sdk"],
+
+    "@syner/slack": ["@syner/slack@workspace:extensions/slack"],
 
     "@syner/typescript": ["@syner/typescript@workspace:tooling/typescript"],
 
@@ -841,6 +865,8 @@
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
+    "@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
+
     "@types/through": ["@types/through@0.0.33", "", { "dependencies": { "@types/node": "*" } }, "sha512-HsJ+z3QuETzP3cswwtzt2vEIiHBk/dCcHGhbmG5X3ecnwFD/lPrMpliGXxSCg03L9AhrdwA4Oz/qfspkDW+xGQ=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
@@ -925,9 +951,13 @@
 
     "async-retry": ["async-retry@1.3.3", "", { "dependencies": { "retry": "0.13.1" } }, "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw=="],
 
+    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
+
     "available-typed-arrays": ["available-typed-arrays@1.0.7", "", { "dependencies": { "possible-typed-array-names": "^1.0.0" } }, "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ=="],
 
     "axe-core": ["axe-core@4.11.1", "", {}, "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A=="],
+
+    "axios": ["axios@1.13.5", "", { "dependencies": { "follow-redirects": "^1.15.11", "form-data": "^4.0.5", "proxy-from-env": "^1.1.0" } }, "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q=="],
 
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
@@ -1005,6 +1035,8 @@
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
+    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
     "commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
@@ -1048,6 +1080,8 @@
     "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
 
     "del": ["del@5.1.0", "", { "dependencies": { "globby": "^10.0.1", "graceful-fs": "^4.2.2", "is-glob": "^4.0.1", "is-path-cwd": "^2.2.0", "is-path-inside": "^3.0.1", "p-map": "^3.0.0", "rimraf": "^3.0.0", "slash": "^3.0.0" } }, "sha512-wH9xOVHnczo9jN2IW68BabcecVPxacIA3g/7z6vhSU/4stOKQzeCRK0yD0A24WiAAUJmmVpWqrERcTxnLo3AnA=="],
+
+    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
 
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
@@ -1151,6 +1185,8 @@
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
+    "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
+
     "events-universal": ["events-universal@1.0.1", "", { "dependencies": { "bare-events": "^2.7.0" } }, "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw=="],
 
     "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
@@ -1189,7 +1225,11 @@
 
     "flatted": ["flatted@3.3.3", "", {}, "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg=="],
 
+    "follow-redirects": ["follow-redirects@1.15.11", "", {}, "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ=="],
+
     "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
+
+    "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
 
     "framer-motion": ["framer-motion@12.34.2", "", { "dependencies": { "motion-dom": "^12.34.2", "motion-utils": "^12.29.2", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-CcnYTzbRybm1/OE8QLXfXI8gR1cx5T4dF3D2kn5IyqsGNeLAKl2iFHb2BzFyXBGqESntDt6rPYl4Jhrb7tdB8g=="],
 
@@ -1321,6 +1361,8 @@
 
     "is-decimal": ["is-decimal@2.0.1", "", {}, "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A=="],
 
+    "is-electron": ["is-electron@2.2.2", "", {}, "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg=="],
+
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
     "is-finalizationregistry": ["is-finalizationregistry@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3" } }, "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg=="],
@@ -1354,6 +1396,8 @@
     "is-set": ["is-set@2.0.3", "", {}, "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg=="],
 
     "is-shared-array-buffer": ["is-shared-array-buffer@1.0.4", "", { "dependencies": { "call-bound": "^1.0.3" } }, "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A=="],
+
+    "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
 
     "is-string": ["is-string@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3", "has-tostringtag": "^1.0.2" } }, "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA=="],
 
@@ -1573,6 +1617,10 @@
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
+    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
     "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
 
     "minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
@@ -1653,11 +1701,19 @@
 
     "own-keys": ["own-keys@1.0.1", "", { "dependencies": { "get-intrinsic": "^1.2.6", "object-keys": "^1.1.1", "safe-push-apply": "^1.0.0" } }, "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg=="],
 
+    "p-finally": ["p-finally@1.0.0", "", {}, "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow=="],
+
     "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
     "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
 
     "p-map": ["p-map@3.0.0", "", { "dependencies": { "aggregate-error": "^3.0.0" } }, "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ=="],
+
+    "p-queue": ["p-queue@6.6.2", "", { "dependencies": { "eventemitter3": "^4.0.4", "p-timeout": "^3.2.0" } }, "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ=="],
+
+    "p-retry": ["p-retry@4.6.2", "", { "dependencies": { "@types/retry": "0.12.0", "retry": "^0.13.1" } }, "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ=="],
+
+    "p-timeout": ["p-timeout@3.2.0", "", { "dependencies": { "p-finally": "^1.0.0" } }, "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg=="],
 
     "param-case": ["param-case@2.1.1", "", { "dependencies": { "no-case": "^2.2.0" } }, "sha512-eQE845L6ot89sk2N8liD8HAuH4ca6Vvr7VWAWwt7+kvvG5aBcPmmphQ68JsEG2qa9n1TykS2DLeMt363AAH8/w=="],
 
@@ -1712,6 +1768,8 @@
     "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
 
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
+
+    "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
@@ -2166,6 +2224,8 @@
     "octokit/@octokit/types": ["@octokit/types@14.1.0", "", { "dependencies": { "@octokit/openapi-types": "^25.1.0" } }, "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g=="],
 
     "os/@types/node": ["@types/node@20.19.33", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw=="],
+
+    "p-queue/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 

--- a/extensions/slack/package.json
+++ b/extensions/slack/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@syner/slack",
+  "description": "Slack integration for Syner OS",
+  "version": "0.0.0-dev.1",
+  "type": "module",
+  "private": false,
+  "sideEffects": false,
+  "license": "MIT",
+  "prettier": "@syner/prettier",
+  "author": {
+    "name": "SynerOps, Inc",
+    "email": "info@synerops.com",
+    "url": "https://synerops.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/synerops/syner.git",
+    "directory": "extensions/slack"
+  },
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "main": "./dist/index.js",
+  "types": "./src/index.d.ts",
+  "files": [
+    "dist",
+    "src/index.d.ts",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint . --max-warnings 0",
+    "format": "prettier --check . --ignore-path ../../.gitignore",
+    "format:fix": "prettier --write . --ignore-path ../../.gitignore",
+    "clean": "rm -rf dist .turbo"
+  },
+  "dependencies": {
+    "@slack/web-api": "^7"
+  },
+  "devDependencies": {
+    "@syner/eslint": "workspace:*",
+    "@syner/prettier": "workspace:*",
+    "@syner/typescript": "workspace:*",
+    "@types/bun": "*",
+    "tsup": "^8.5.0",
+    "typescript": "catalog:"
+  }
+}

--- a/extensions/slack/src/client.ts
+++ b/extensions/slack/src/client.ts
@@ -1,0 +1,127 @@
+/**
+ * Slack Client
+ *
+ * Thin wrapper over @slack/web-api WebClient.
+ * Exposes methods matching the bot scopes:
+ * - chat:write (sendMessage, replyInThread)
+ * - im:write (same methods, DM channels)
+ * - assistant:write (setStatus, setTitle, setSuggestedPrompts)
+ */
+
+import { WebClient } from '@slack/web-api'
+import type { SlackClientOptions } from './types'
+
+export type SlackClient = WebClient
+
+/**
+ * Creates an authenticated Slack Web API client.
+ *
+ * @example
+ * ```ts
+ * const client = createSlackClient({ botToken: process.env.SLACK_BOT_TOKEN! })
+ * await sendMessage(client, { channel: 'C123', text: 'Hello!' })
+ * ```
+ */
+export function createSlackClient(options: SlackClientOptions): SlackClient {
+  return new WebClient(options.botToken)
+}
+
+// ============================================================================
+// chat:write + im:write
+// ============================================================================
+
+export interface SendMessageOptions {
+  channel: string
+  text: string
+  threadTs?: string
+  mrkdwn?: boolean
+}
+
+/**
+ * Sends a message to a channel or DM.
+ */
+export async function sendMessage(client: SlackClient, options: SendMessageOptions) {
+  return client.chat.postMessage({
+    channel: options.channel,
+    text: options.text,
+    thread_ts: options.threadTs,
+    mrkdwn: options.mrkdwn ?? true,
+  })
+}
+
+/**
+ * Replies in a thread. Shorthand for sendMessage with threadTs.
+ */
+export async function replyInThread(
+  client: SlackClient,
+  options: { channel: string; threadTs: string; text: string }
+) {
+  return sendMessage(client, {
+    channel: options.channel,
+    text: options.text,
+    threadTs: options.threadTs,
+  })
+}
+
+// ============================================================================
+// assistant:write
+// ============================================================================
+
+export interface SetAssistantStatusOptions {
+  channelId: string
+  threadTs: string
+  status: string
+}
+
+/**
+ * Sets the assistant's typing/processing status in a thread.
+ */
+export async function setAssistantStatus(client: SlackClient, options: SetAssistantStatusOptions) {
+  return client.assistant.threads.setStatus({
+    channel_id: options.channelId,
+    thread_ts: options.threadTs,
+    status: options.status,
+  })
+}
+
+export interface SetAssistantTitleOptions {
+  channelId: string
+  threadTs: string
+  title: string
+}
+
+/**
+ * Sets the title of an assistant thread.
+ */
+export async function setAssistantTitle(client: SlackClient, options: SetAssistantTitleOptions) {
+  return client.assistant.threads.setTitle({
+    channel_id: options.channelId,
+    thread_ts: options.threadTs,
+    title: options.title,
+  })
+}
+
+export interface SuggestedPrompt {
+  title: string
+  message: string
+}
+
+export interface SetAssistantSuggestedPromptsOptions {
+  channelId: string
+  threadTs: string
+  prompts: SuggestedPrompt[]
+}
+
+/**
+ * Sets suggested prompts for the assistant thread.
+ */
+export async function setAssistantSuggestedPrompts(
+  client: SlackClient,
+  options: SetAssistantSuggestedPromptsOptions
+) {
+  return client.assistant.threads.setSuggestedPrompts({
+    channel_id: options.channelId,
+    thread_ts: options.threadTs,
+    prompts: options.prompts,
+  })
+}

--- a/extensions/slack/src/handler.ts
+++ b/extensions/slack/src/handler.ts
@@ -20,6 +20,11 @@
  * const handler = createHandler({ signingSecret: '...' })
  * const response = await handler(request)
  * ```
+ *
+ * Note: Callbacks are fire-and-forget — the handler returns 200
+ * immediately to meet Slack's 3-second deadline. On serverless
+ * platforms, use `after()` or `waitUntil()` inside callbacks
+ * to keep the function alive until async work completes.
  */
 
 import { createHmac, timingSafeEqual } from 'node:crypto'
@@ -105,10 +110,10 @@ export function createHandler(options: SlackHandlerOptions) {
       })
     }
 
-    // Event callback — dispatch to handlers
+    // Event callback — fire and forget, respond 200 immediately.
+    // Slack enforces a 3-second timeout on event acknowledgment.
     if (payload.type === 'event_callback') {
-      // Acknowledge immediately, then dispatch
-      await dispatch(options, payload)
+      Promise.resolve(dispatch(options, payload)).catch(console.error)
     }
 
     return new Response('ok', { status: 200 })

--- a/extensions/slack/src/handler.ts
+++ b/extensions/slack/src/handler.ts
@@ -1,0 +1,154 @@
+/**
+ * Slack Webhook Handler
+ *
+ * Framework-agnostic handler using Web API Request/Response.
+ * Verifies request signatures, handles url_verification,
+ * and dispatches events to callbacks.
+ *
+ * @example
+ * ```ts
+ * // Next.js API route (one-liner)
+ * import { createHandler } from '@syner/slack'
+ *
+ * export const POST = createHandler({
+ *   signingSecret: process.env.SLACK_SIGNING_SECRET!,
+ *   onAppMention: async (event) => { ... },
+ *   onAssistantThreadStarted: async (event) => { ... },
+ * })
+ *
+ * // Any framework
+ * const handler = createHandler({ signingSecret: '...' })
+ * const response = await handler(request)
+ * ```
+ */
+
+import { createHmac, timingSafeEqual } from 'node:crypto'
+import type {
+  SlackHandlerOptions,
+  SlackPayload,
+  SlackEventCallback,
+  AppMentionEvent,
+  AssistantThreadStartedEvent,
+  AssistantThreadContextChangedEvent,
+  MessageEvent,
+} from './types'
+
+/** Maximum age of a request timestamp (5 minutes) */
+const MAX_TIMESTAMP_AGE_S = 300
+
+/**
+ * Verifies a Slack request signature.
+ *
+ * @see https://api.slack.com/authentication/verifying-requests-from-slack
+ */
+function verifySignature(
+  headers: Headers,
+  body: string,
+  signingSecret: string
+): boolean {
+  const timestamp = headers.get('x-slack-request-timestamp')
+  const signature = headers.get('x-slack-signature')
+
+  if (!timestamp || !signature) return false
+
+  // Reject requests older than 5 minutes (replay protection)
+  const now = Math.floor(Date.now() / 1000)
+  if (Math.abs(now - Number(timestamp)) > MAX_TIMESTAMP_AGE_S) return false
+
+  // Compute expected signature: v0=sha256(v0:timestamp:body)
+  const baseString = `v0:${timestamp}:${body}`
+  const expected = `v0=${createHmac('sha256', signingSecret).update(baseString).digest('hex')}`
+
+  // Timing-safe comparison
+  try {
+    return timingSafeEqual(Buffer.from(signature), Buffer.from(expected))
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Creates a framework-agnostic Slack webhook handler.
+ *
+ * Returns an async function that takes a Web API Request
+ * and returns a Web API Response. Wire it directly to your
+ * API route — no framework glue needed.
+ */
+export function createHandler(options: SlackHandlerOptions) {
+  const { signingSecret } = options
+
+  return async (req: Request): Promise<Response> => {
+    // Only accept POST
+    if (req.method !== 'POST') {
+      return new Response('Method Not Allowed', { status: 405 })
+    }
+
+    const body = await req.text()
+
+    // Verify request authenticity
+    if (!verifySignature(req.headers, body, signingSecret)) {
+      return new Response('Unauthorized', { status: 401 })
+    }
+
+    let payload: SlackPayload
+    try {
+      payload = JSON.parse(body) as SlackPayload
+    } catch {
+      return new Response('Bad Request', { status: 400 })
+    }
+
+    // URL verification challenge (Slack app setup)
+    if (payload.type === 'url_verification') {
+      return new Response(JSON.stringify({ challenge: payload.challenge }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    }
+
+    // Event callback — dispatch to handlers
+    if (payload.type === 'event_callback') {
+      // Acknowledge immediately, then dispatch
+      await dispatch(options, payload)
+    }
+
+    return new Response('ok', { status: 200 })
+  }
+}
+
+/**
+ * Dispatches a Slack event to the appropriate callback.
+ */
+async function dispatch(
+  options: SlackHandlerOptions,
+  envelope: SlackEventCallback
+): Promise<void> {
+  const { event } = envelope
+
+  switch (event.type) {
+    case 'app_mention':
+      await options.onAppMention?.(event as AppMentionEvent, envelope as SlackEventCallback<AppMentionEvent>)
+      break
+
+    case 'assistant_thread_started':
+      await options.onAssistantThreadStarted?.(
+        event as AssistantThreadStartedEvent,
+        envelope as SlackEventCallback<AssistantThreadStartedEvent>
+      )
+      break
+
+    case 'assistant_thread_context_changed':
+      await options.onAssistantThreadContextChanged?.(
+        event as AssistantThreadContextChangedEvent,
+        envelope as SlackEventCallback<AssistantThreadContextChangedEvent>
+      )
+      break
+
+    case 'message': {
+      const msg = event as MessageEvent
+      // Skip bot messages to prevent loops
+      if (msg.bot_id || msg.subtype) break
+      await options.onMessage?.(msg, envelope as SlackEventCallback<MessageEvent>)
+      break
+    }
+  }
+}

--- a/extensions/slack/src/index.d.ts
+++ b/extensions/slack/src/index.d.ts
@@ -1,0 +1,167 @@
+/**
+ * @syner/slack type declarations
+ */
+
+import type { WebClient } from '@slack/web-api'
+
+// ============================================================================
+// Event Types
+// ============================================================================
+
+export interface SlackUrlVerification {
+  type: 'url_verification'
+  token: string
+  challenge: string
+}
+
+export interface SlackEventCallback<E = SlackEvent> {
+  type: 'event_callback'
+  token: string
+  team_id: string
+  api_app_id: string
+  event: E
+  event_id: string
+  event_time: number
+}
+
+export type SlackPayload = SlackUrlVerification | SlackEventCallback
+
+export interface AppMentionEvent {
+  type: 'app_mention'
+  user: string
+  text: string
+  ts: string
+  channel: string
+  event_ts: string
+  thread_ts?: string
+}
+
+export interface AssistantThreadContext {
+  channel_id: string
+  team_id: string
+  enterprise_id?: string
+}
+
+export interface AssistantThread {
+  user_id: string
+  context: AssistantThreadContext
+  channel_id: string
+  thread_ts: string
+}
+
+export interface AssistantThreadStartedEvent {
+  type: 'assistant_thread_started'
+  assistant_thread: AssistantThread
+}
+
+export interface AssistantThreadContextChangedEvent {
+  type: 'assistant_thread_context_changed'
+  assistant_thread: AssistantThread
+}
+
+export interface MessageEvent {
+  type: 'message'
+  channel: string
+  user: string
+  text: string
+  ts: string
+  thread_ts?: string
+  channel_type: 'im' | 'channel' | 'group' | 'mpim'
+  subtype?: string
+  bot_id?: string
+}
+
+export type SlackEvent =
+  | AppMentionEvent
+  | AssistantThreadStartedEvent
+  | AssistantThreadContextChangedEvent
+  | MessageEvent
+
+// ============================================================================
+// Handler
+// ============================================================================
+
+export interface SlackHandlerOptions {
+  signingSecret: string
+  onAppMention?: (event: AppMentionEvent, envelope: SlackEventCallback<AppMentionEvent>) => Promise<void>
+  onAssistantThreadStarted?: (
+    event: AssistantThreadStartedEvent,
+    envelope: SlackEventCallback<AssistantThreadStartedEvent>
+  ) => Promise<void>
+  onAssistantThreadContextChanged?: (
+    event: AssistantThreadContextChangedEvent,
+    envelope: SlackEventCallback<AssistantThreadContextChangedEvent>
+  ) => Promise<void>
+  onMessage?: (event: MessageEvent, envelope: SlackEventCallback<MessageEvent>) => Promise<void>
+}
+
+export declare function createHandler(
+  options: SlackHandlerOptions
+): (req: Request) => Promise<Response>
+
+// ============================================================================
+// Client
+// ============================================================================
+
+export type SlackClient = WebClient
+
+export interface SlackClientOptions {
+  botToken: string
+}
+
+export declare function createSlackClient(options: SlackClientOptions): SlackClient
+
+export interface SendMessageOptions {
+  channel: string
+  text: string
+  threadTs?: string
+  mrkdwn?: boolean
+}
+
+export declare function sendMessage(
+  client: SlackClient,
+  options: SendMessageOptions
+): Promise<unknown>
+
+export declare function replyInThread(
+  client: SlackClient,
+  options: { channel: string; threadTs: string; text: string }
+): Promise<unknown>
+
+export interface SetAssistantStatusOptions {
+  channelId: string
+  threadTs: string
+  status: string
+}
+
+export declare function setAssistantStatus(
+  client: SlackClient,
+  options: SetAssistantStatusOptions
+): Promise<unknown>
+
+export interface SetAssistantTitleOptions {
+  channelId: string
+  threadTs: string
+  title: string
+}
+
+export declare function setAssistantTitle(
+  client: SlackClient,
+  options: SetAssistantTitleOptions
+): Promise<unknown>
+
+export interface SuggestedPrompt {
+  title: string
+  message: string
+}
+
+export interface SetAssistantSuggestedPromptsOptions {
+  channelId: string
+  threadTs: string
+  prompts: SuggestedPrompt[]
+}
+
+export declare function setAssistantSuggestedPrompts(
+  client: SlackClient,
+  options: SetAssistantSuggestedPromptsOptions
+): Promise<unknown>

--- a/extensions/slack/src/index.ts
+++ b/extensions/slack/src/index.ts
@@ -1,0 +1,56 @@
+/**
+ * @syner/slack - Slack Integration
+ *
+ * Framework-agnostic Slack integration for Syner OS:
+ * - Webhook handler with signature verification
+ * - Client for chat, DMs, and assistant threads
+ *
+ * @example
+ * ```ts
+ * import { createHandler, createSlackClient, sendMessage } from '@syner/slack'
+ *
+ * // Wire handler to your API route
+ * export const POST = createHandler({
+ *   signingSecret: process.env.SLACK_SIGNING_SECRET!,
+ *   onAppMention: async (event) => {
+ *     const client = createSlackClient({ botToken: process.env.SLACK_BOT_TOKEN! })
+ *     await sendMessage(client, { channel: event.channel, text: 'Hello!', threadTs: event.ts })
+ *   },
+ * })
+ * ```
+ */
+
+// Handler
+export { createHandler } from './handler'
+
+// Client
+export {
+  createSlackClient,
+  sendMessage,
+  replyInThread,
+  setAssistantStatus,
+  setAssistantTitle,
+  setAssistantSuggestedPrompts,
+  type SlackClient,
+  type SendMessageOptions,
+  type SetAssistantStatusOptions,
+  type SetAssistantTitleOptions,
+  type SuggestedPrompt,
+  type SetAssistantSuggestedPromptsOptions,
+} from './client'
+
+// Types
+export type {
+  SlackHandlerOptions,
+  SlackClientOptions,
+  SlackPayload,
+  SlackUrlVerification,
+  SlackEventCallback,
+  SlackEvent,
+  AppMentionEvent,
+  AssistantThreadStartedEvent,
+  AssistantThreadContextChangedEvent,
+  AssistantThread,
+  AssistantThreadContext,
+  MessageEvent,
+} from './types'

--- a/extensions/slack/src/types.ts
+++ b/extensions/slack/src/types.ts
@@ -1,0 +1,119 @@
+/**
+ * Slack Event Types
+ *
+ * Type definitions for Slack Events API payloads.
+ * Covers: app_mention, assistant threads, and direct messages.
+ */
+
+// ============================================================================
+// Event Envelope
+// ============================================================================
+
+export interface SlackUrlVerification {
+  type: 'url_verification'
+  token: string
+  challenge: string
+}
+
+export interface SlackEventCallback<E = SlackEvent> {
+  type: 'event_callback'
+  token: string
+  team_id: string
+  api_app_id: string
+  event: E
+  event_id: string
+  event_time: number
+}
+
+export type SlackPayload = SlackUrlVerification | SlackEventCallback
+
+// ============================================================================
+// Events
+// ============================================================================
+
+export interface AppMentionEvent {
+  type: 'app_mention'
+  user: string
+  text: string
+  ts: string
+  channel: string
+  event_ts: string
+  thread_ts?: string
+}
+
+export interface AssistantThreadContext {
+  channel_id: string
+  team_id: string
+  enterprise_id?: string
+}
+
+export interface AssistantThread {
+  user_id: string
+  context: AssistantThreadContext
+  channel_id: string
+  thread_ts: string
+}
+
+export interface AssistantThreadStartedEvent {
+  type: 'assistant_thread_started'
+  assistant_thread: AssistantThread
+}
+
+export interface AssistantThreadContextChangedEvent {
+  type: 'assistant_thread_context_changed'
+  assistant_thread: AssistantThread
+}
+
+export interface MessageEvent {
+  type: 'message'
+  channel: string
+  user: string
+  text: string
+  ts: string
+  thread_ts?: string
+  channel_type: 'im' | 'channel' | 'group' | 'mpim'
+  subtype?: string
+  bot_id?: string
+}
+
+export type SlackEvent =
+  | AppMentionEvent
+  | AssistantThreadStartedEvent
+  | AssistantThreadContextChangedEvent
+  | MessageEvent
+
+// ============================================================================
+// Handler Options
+// ============================================================================
+
+export interface SlackHandlerOptions {
+  /** Slack app signing secret for request verification */
+  signingSecret: string
+
+  /** Called when the bot is @mentioned in a channel */
+  onAppMention?: (event: AppMentionEvent, envelope: SlackEventCallback<AppMentionEvent>) => Promise<void>
+
+  /** Called when a user opens a new assistant thread */
+  onAssistantThreadStarted?: (
+    event: AssistantThreadStartedEvent,
+    envelope: SlackEventCallback<AssistantThreadStartedEvent>
+  ) => Promise<void>
+
+  /** Called when the user's channel context changes during an assistant thread */
+  onAssistantThreadContextChanged?: (
+    event: AssistantThreadContextChangedEvent,
+    envelope: SlackEventCallback<AssistantThreadContextChangedEvent>
+  ) => Promise<void>
+
+  /** Called when a direct message is received */
+  onMessage?: (event: MessageEvent, envelope: SlackEventCallback<MessageEvent>) => Promise<void>
+}
+
+// ============================================================================
+// Client Options
+// ============================================================================
+
+export interface SlackClientOptions {
+  /** Bot User OAuth Token (xoxb-...) */
+  botToken: string
+}

--- a/extensions/slack/tsconfig.json
+++ b/extensions/slack/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@syner/typescript/base",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/extensions/slack/tsup.config.ts
+++ b/extensions/slack/tsup.config.ts
@@ -1,0 +1,19 @@
+// TODO(@claude): tsup cannot be dropped in favor of Bun.build yet:
+// https://github.com/oven-sh/bun/issues/5141
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: {
+    index: 'src/index.ts',
+  },
+  format: ['cjs', 'esm'],
+  dts: false,
+  clean: true,
+  sourcemap: true,
+  target: 'es2020',
+
+  external: ['@slack/web-api', /^node:/],
+
+  splitting: false,
+  treeshake: true,
+})


### PR DESCRIPTION
Framework-agnostic Slack integration using Web API Request/Response:
- handler.ts: webhook handler with signature verification, event dispatch
- client.ts: Web API wrapper for chat, DMs, and assistant threads
- Supports: app_mention, assistant_thread_started, assistant_thread_context_changed, message.im

Scopes: app_mentions:read, chat:write, im:history, im:write, assistant:write

TODO: create issue to refactor existing extensions to same pattern

https://claude.ai/code/session_01UV3tqx7Bc8DDDx2ZVusxFv