### PR TITLE
feat: add surface-specific system prompt for Slack

### DIFF
--- a/apps/dev/app/api/slack/webhook/route.ts
+++ b/apps/dev/app/api/slack/webhook/route.ts
@@ -13,7 +13,41 @@
 
 import { after } from 'next/server'
 import { createHandler, createSlackClient, replyInThread, setAssistantStatus } from '@syner/slack'
-import { think } from 'syner'
+import { think, card } from 'syner'
+
+const SLACK_SYSTEM_PROMPT = `You are ${card().name}, an AI assistant for Slack that understands what you need and coordinates tools and agents to get things done.
+
+<identity>
+${card().description}
+</identity>
+
+<instructions>
+- Respond conversationally. You're in a chat, not writing a document.
+- Be concise. Most messages should be 1-3 short paragraphs.
+- Never show internal reasoning (no "Classifying request", "Strategy", headers).
+- Use Slack formatting: *bold*, _italic_, \`code\`. No markdown headers.
+- Match the user's language. Spanish → Spanish. English → English.
+- Match the user's energy. Casual → casual. Technical → focused.
+- If you don't know something, say so directly.
+</instructions>
+
+<examples>
+<example>
+<user>hola syner</user>
+<response>Hola! En qué te puedo ayudar?</response>
+</example>
+
+<example>
+<user>can you help me plan a migration from postgres to planetscale?</user>
+<response>Sure — a few things to figure out first:
+
+• *Schema compatibility*: PlanetScale uses Vitess, so no foreign keys. Do you rely on FKs?
+• *Data volume*: How big is the DB? Affects migration strategy.
+• *Downtime tolerance*: Maintenance window ok, or zero-downtime?
+
+Once I know those, I can sketch a plan.</response>
+</example>
+</examples>`
 
 function getSlackClient() {
   const botToken = process.env.SLACK_BOT_TOKEN
@@ -33,7 +67,7 @@ export const POST = createHandler({
 
     await setAssistantStatus(client, { channelId: channel, threadTs, status: 'Thinking...' })
 
-    const { text } = await think(event.text)
+    const { text } = await think(event.text, { systemPrompt: SLACK_SYSTEM_PROMPT })
     await replyInThread(client, { channel, threadTs, text })
   },
 
@@ -47,7 +81,9 @@ export const POST = createHandler({
       status: 'Thinking...',
     })
 
-    const { text } = await think('A new conversation has started. Introduce yourself briefly.')
+    const { text } = await think('A new conversation has started. Introduce yourself briefly.', {
+      systemPrompt: SLACK_SYSTEM_PROMPT,
+    })
     await replyInThread(client, { channel: channel_id, threadTs: thread_ts, text })
   },
 
@@ -68,7 +104,7 @@ export const POST = createHandler({
 
     await setAssistantStatus(client, { channelId: channel, threadTs, status: 'Thinking...' })
 
-    const { text } = await think(event.text)
+    const { text } = await think(event.text, { systemPrompt: SLACK_SYSTEM_PROMPT })
     await replyInThread(client, { channel, threadTs, text })
   },
 })

--- a/packages/syner/SYNER.md
+++ b/packages/syner/SYNER.md
@@ -10,7 +10,7 @@ You are Syner. The orchestrator agent of Syner OS.
 
 ## How you think
 
-Every request follows this sequence. No exceptions.
+Every request follows this sequence:
 
 1. **Classify** the request — what kind of work is this?
 2. **Choose** a strategy — which pattern fits best?
@@ -18,6 +18,8 @@ Every request follows this sequence. No exceptions.
 4. **Synthesize** — combine results into a coherent response
 
 You orchestrate, you don't execute. Others produce artifacts — you produce clarity.
+
+For complex work, show your reasoning. For simple interactions, respond directly.
 
 ## Agent Loop
 

--- a/packages/syner/brain.ts
+++ b/packages/syner/brain.ts
@@ -6,10 +6,9 @@
  */
 
 import { generateText, gateway } from 'ai'
-import { card } from './card'
 
 export interface ThinkOptions {
-  systemPrompt?: string
+  systemPrompt: string
   model?: string
 }
 
@@ -17,16 +16,14 @@ export interface ThinkResponse {
   text: string
 }
 
-export async function think(prompt: string, options?: ThinkOptions): Promise<ThinkResponse> {
-  const modelId = options?.model
+export async function think(prompt: string, options: ThinkOptions): Promise<ThinkResponse> {
+  const modelId = options.model
     ?? process.env.SYNER_ASSISTANT_MODEL
     ?? 'anthropic/claude-sonnet-4'
 
-  const systemPrompt = options?.systemPrompt ?? card().content
-
   const result = await generateText({
     model: gateway(modelId),
-    system: systemPrompt,
+    system: options.systemPrompt,
     prompt,
   })
 


### PR DESCRIPTION
## Summary

- **`systemPrompt` is now required in `think()`** — removes the implicit fallback to `card().content` (orchestrator prompt), forcing each surface to define its own prompt
- **Added `SLACK_SYSTEM_PROMPT`** in the webhook route, using `card().name` and `card().description` as building blocks with Slack-specific instructions and few-shot examples
- **Removed "No exceptions" from SYNER.md** and added flexibility line for simple interactions

## Context

Syner was exposing internal reasoning in Slack (`## Classifying Request`, `## Strategy: Direct Response`) because `think()` defaulted to the orchestrator prompt from SYNER.md. This PR implements the consensus from the team discussion in `chat.md`: brain-wire's core fix + slack-surface's dedicated prompt + required `systemPrompt`.

## Test plan

- [ ] Deploy to Vercel preview
- [ ] Send "hola syner" in Slack — should get a casual, direct response without headers
- [ ] Send a technical question — should get a focused answer with Slack formatting
- [ ] Verify `card().name` and `card().description` resolve correctly in the prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)