### PR TITLE
fix: handle setAssistantStatus errors in Slack webhook

### DIFF
--- a/apps/dev/app/api/slack/webhook/route.ts
+++ b/apps/dev/app/api/slack/webhook/route.ts
@@ -105,12 +105,11 @@ export const POST = createHandler({
     const channel = event.channel
     const threadTs = event.thread_ts ?? event.ts
 
-    await setAssistantStatus(client, { channelId: channel, threadTs, status: 'Thinking...' })
+    // Note: setAssistantStatus only works in assistant threads, not regular mentions
 
     const { text } = await think(event.text, {
       systemPrompt: SLACK_SYSTEM_PROMPT,
       tools: getTools(),
-      maxSteps: 5,
     })
     await replyInThread(client, { channel, threadTs, text })
   },
@@ -146,12 +145,16 @@ export const POST = createHandler({
     const channel = event.channel
     const threadTs = event.thread_ts ?? event.ts
 
-    await setAssistantStatus(client, { channelId: channel, threadTs, status: 'Thinking...' })
+    // Try to set status, but don't fail if not an assistant thread
+    try {
+      await setAssistantStatus(client, { channelId: channel, threadTs, status: 'Thinking...' })
+    } catch {
+      // Not an assistant thread, ignore
+    }
 
     const { text } = await think(event.text, {
       systemPrompt: SLACK_SYSTEM_PROMPT,
       tools: getTools(),
-      maxSteps: 5,
     })
     await replyInThread(client, { channel, threadTs, text })
   },


### PR DESCRIPTION
## Summary

- Remove `setAssistantStatus` from `onAppMention` (only works in assistant threads, not regular mentions)
- Wrap `setAssistantStatus` in try/catch for `onMessage` (may not be an assistant thread)
- Remove explicit `maxSteps: 5` to use default (20)
- Added missing `GITHUB_APP_ID` and `GITHUB_PRIVATE_KEY` env vars to Vercel

## Errors fixed

```
Error: An API error occurred: invalid_thread_ts
Error: [@octokit/auth-app] appId option is required
```

## Test plan

- [ ] Test in Slack: "@Syner hola que onda"
- [ ] Test in Slack DM thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)